### PR TITLE
Allow qbe to be found in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ crystal build src/cli/c.cr --release -o myc-c
 crystal build src/cli/llvm.cr --release -o myc-llvm 
 
 # compile Myc IR Qbe backend
+# uses `qbe` from PATH, or the one given by the QBE env variable,
+# otherwise build it locally as shown below
 git clone https://github.com/kostya/qbe.git plugins/qbe
 cd plugins/qbe; make; cd -
 crystal build src/cli/qbe.cr --release -o myc-qbe

--- a/src/backend/qbe/backend.cr
+++ b/src/backend/qbe/backend.cr
@@ -1,5 +1,5 @@
 class Myc::Backend::QBE::Backend < Myc::Backend::AbstractBackend
-  QBE = ENV["QBE"]? || File.join(File.dirname(__FILE__), "..", "..", "..", "plugins", "qbe", "qbe")
+  QBE = ENV["QBE"]? || Process.find_executable("qbe") || File.join(File.dirname(__FILE__), "..", "..", "..", "plugins", "qbe", "qbe")
   AS  = ENV["AS"]? || "as"
 
   def name


### PR DESCRIPTION
An installed myc-qbe cannot reach plugins/qbe, since that fallback path is baked in at compile time and points at the source tree used to build the binary. Distributions and users who already have qbe available had to set the QBE variable on every invocation.

Lookup now falls back to PATH before the bundled build, so a system qbe works out of the box. The QBE variable still takes precedence, and plugins/qbe remains the last resort.

Closes #3